### PR TITLE
Add GitHub Skills Activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,6 +75,13 @@ activities = {
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
+    ,
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the official GitHub Certifications program.",
+        "schedule": "Mondays, 5:00 PM - 6:00 PM",
+        "max_participants": 25,
+        "participants": []
+    }
 }
 
 


### PR DESCRIPTION
This PR adds the GitHub Skills activity to the school activities system, addressing issue #6.

### Changes Made
- Added new "GitHub Skills" activity with:
  - Description highlighting GitHub Certifications program
  - Weekly schedule on Mondays
  - Capacity for 25 students
  - Empty initial participants list

### Testing
- Activity appears in the list
- Students can register for the new activity
- Follows same format as other activities

Fixes #6